### PR TITLE
fix: undefined LmhpFragmentationParams_t compilation error

### DIFF
--- a/cores/STM32WLE/component/service/lora/service_lora.c
+++ b/cores/STM32WLE/component/service/lora/service_lora.c
@@ -116,6 +116,7 @@ extern bool udrv_powersave_in_sleep;
 extern uint8_t last_tx_channel; 
 static udrv_system_event_t rui_lora_join_cb_event = {.request = UDRV_SYS_EVT_OP_LORAWAN_JOIN_CB, .p_context = NULL};
 
+#ifdef SUPPORT_FUOTA
 static LmhpFragmentationParams_t LmhpFragmentationParam1 =
 {
     /*.DecoderCallbacks =
@@ -126,6 +127,7 @@ static LmhpFragmentationParams_t LmhpFragmentationParam1 =
     .OnProgress = fuota_OnFragProgress,
     .OnDone = fuota_OnFragDone,*/
 };
+#endif // SUPPORT_FUOTA
 
 static SingleChannel_t SingleChannelAU915 =
 {


### PR DESCRIPTION
Compiling current main without the `SUPPORT_FUOTA` flag set results in an error

<img width="931" height="236" alt="image" src="https://github.com/user-attachments/assets/d31d7d69-7b86-48e6-845a-e9558eb65dce" />

Because this type is use which is only defined if `SUPPORT_FUOTA` flag is set.
https://github.com/RAKWireless/RAK-STM32-RUI/blob/main/cores/STM32WLE/component/service/lora/service_lora.c#L119-L128

This should also be checked on the new v5.0 branch (I did not check it yet). 